### PR TITLE
Add uninstall to the makefile and fix building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 BINFILE ?= ptar
 
 # compilation flags
-CFLAGS ?= -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -O2 -g -Wall -Werror
+CFLAGS ?= -D_XOPEN_SOURCE=700 -D_BSD_SOURCE -O2 -g -Wall
 CPPFLAGS ?=
 
 # the installation program (install(1))

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ clean:
 install: $(BINFILE)
 	$(INSTALL_PROGRAM) $(BINFILE) $(BINDIR)/$(BINFILE)
 
+uninstall:
+	rm -f $(BINDIR)/$(BINFILE)
+
 dist: $(DISTARCHIVE)
 
 $(DISTARCHIVE): all


### PR DESCRIPTION
`make uninstall` could be useful here.
When releasing something, I think that Werror is a bit harsh.
It often breaks the build needlessly, for example because of
unused variables. For developing, it is okay, but not when
releasing into the wild.
Have a nice day.