### PR TITLE
Add required <sys/sysmacros.h> to ptar.c

### DIFF
--- a/ptar.c
+++ b/ptar.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <sys/param.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
In order to compile, a missing include file, <sys/sysmacros.h> is needed. This single line commit simply adds it.